### PR TITLE
Criacao das services para copiar as linhas da base de dados da api data poa.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,17 @@
 			<artifactId>springfox-swagger-ui</artifactId>
 			<version>2.9.2</version>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.modelmapper</groupId>
+			<artifactId>modelmapper</artifactId>
+			<version>2.4.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/mobil/config/bean/BeanSupplier.java
+++ b/src/main/java/com/mobil/config/bean/BeanSupplier.java
@@ -1,0 +1,38 @@
+package com.mobil.config.bean;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Configuration
+public class BeanSupplier {
+
+    @Bean
+    public RestTemplate restTemplate() {
+
+        final RestTemplate restTemplate = new RestTemplate();
+
+        final List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
+
+        final MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+
+        converter.setSupportedMediaTypes(Collections.singletonList(MediaType.ALL));
+        messageConverters.add(converter);
+        restTemplate.setMessageConverters(messageConverters);
+
+        return restTemplate;
+    }
+
+    @Bean
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
+}

--- a/src/main/java/com/mobil/integration/model/in/LinhaIn.java
+++ b/src/main/java/com/mobil/integration/model/in/LinhaIn.java
@@ -1,0 +1,17 @@
+package com.mobil.integration.model.in;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode
+public class LinhaIn {
+
+    private long id;
+
+    private String codigo;
+
+    private String nome;
+}

--- a/src/main/java/com/mobil/integration/service/BuscaLinhasService.java
+++ b/src/main/java/com/mobil/integration/service/BuscaLinhasService.java
@@ -1,0 +1,35 @@
+package com.mobil.integration.service;
+
+import com.mobil.integration.model.in.LinhaIn;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.mobil.integration.util.enums.MensagemErro.ERRO_INESPERADO;
+
+@RequiredArgsConstructor
+@Service
+public class BuscaLinhasService {
+
+    @Value("${integration.lista-linhas.url}")
+    private String url;
+
+    private final RestTemplate restTemplate;
+
+    public List<LinhaIn> buscarLinhas() {
+        return Arrays.asList(
+                Optional.ofNullable(restTemplate.getForObject(
+                        url,
+                        LinhaIn[].class))
+                        .orElseThrow(() -> new ResponseStatusException(
+                                HttpStatus.BAD_GATEWAY,
+                                ERRO_INESPERADO.mensagem())));
+    }
+}

--- a/src/main/java/com/mobil/integration/service/CopiaBaseDadosService.java
+++ b/src/main/java/com/mobil/integration/service/CopiaBaseDadosService.java
@@ -1,0 +1,26 @@
+package com.mobil.integration.service;
+
+import com.mobil.integration.model.in.LinhaIn;
+import com.mobil.model.entity.Linha;
+import com.mobil.model.out.LinhaOut;
+import com.mobil.util.converter.LinhasToLinhasOutConverter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class CopiaBaseDadosService {
+
+    private final BuscaLinhasService buscaLinhasService;
+    private final SalvaLinhasInService salvaLinhasInService;
+    private final LinhasToLinhasOutConverter linhasToLinhasOutConverter;
+
+    public List<LinhaOut> copiarBaseDados() {
+        final List<LinhaIn> linhasIn = buscaLinhasService.buscarLinhas();
+        final List<Linha> linhas = salvaLinhasInService.salvarLinhas(linhasIn);
+
+        return linhasToLinhasOutConverter.convert(linhas);
+    }
+}

--- a/src/main/java/com/mobil/integration/service/SalvaLinhasInService.java
+++ b/src/main/java/com/mobil/integration/service/SalvaLinhasInService.java
@@ -1,0 +1,34 @@
+package com.mobil.integration.service;
+
+import com.mobil.integration.model.in.LinhaIn;
+import com.mobil.integration.util.converter.LinhasInToLinhasConverter;
+import com.mobil.model.entity.Linha;
+import com.mobil.repository.LinhaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class SalvaLinhasInService {
+
+    private final LinhaRepository repository;
+    private final LinhasInToLinhasConverter linhasInToLinhasConverter;
+
+    public List<Linha> salvarLinhas(final List<LinhaIn> linhasIn) {
+
+        final List<Linha> linhas = linhasInToLinhasConverter.convert(linhasIn);
+
+        final List<Linha> linhasFiltradas = filtrarLinhas(linhas);
+
+        return repository.saveAll(linhasFiltradas);
+    }
+
+    private List<Linha> filtrarLinhas(final List<Linha> linhas) {
+        return Objects.requireNonNull(linhas).stream()
+                .filter(linha -> !repository.existsByCodigo(linha.getCodigo())).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/mobil/integration/util/converter/LinhasInToLinhasConverter.java
+++ b/src/main/java/com/mobil/integration/util/converter/LinhasInToLinhasConverter.java
@@ -1,0 +1,28 @@
+package com.mobil.integration.util.converter;
+
+import com.mobil.integration.model.in.LinhaIn;
+import com.mobil.model.entity.Linha;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Component
+public class LinhasInToLinhasConverter implements Converter<List<LinhaIn>, List<Linha>> {
+
+    private final ModelMapper modelMapper;
+
+    @Override
+    public List<Linha> convert(final List<LinhaIn> linhasIn) {
+
+        if (linhasIn.isEmpty()) {
+            throw new IllegalArgumentException("A lista de LinhaIn não pode ser convertidade em uma lista de Linha.");
+        }
+
+        return linhasIn.stream().map(linhaIn -> modelMapper.map(linhaIn, Linha.class)).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/mobil/integration/util/enums/MensagemErro.java
+++ b/src/main/java/com/mobil/integration/util/enums/MensagemErro.java
@@ -1,0 +1,16 @@
+package com.mobil.integration.util.enums;
+
+public enum MensagemErro {
+
+    ERRO_INESPERADO("Ocorreu um erro inesperado.");
+
+    private final String mensagem;
+
+    MensagemErro(final String mensagem) {
+        this.mensagem = mensagem;
+    }
+
+    public String mensagem() {
+        return mensagem;
+    }
+}

--- a/src/main/java/com/mobil/model/out/LinhaOut.java
+++ b/src/main/java/com/mobil/model/out/LinhaOut.java
@@ -1,0 +1,18 @@
+package com.mobil.model.out;
+
+import com.mobil.model.entity.Itinerario;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class LinhaOut {
+
+    private String codigo;
+
+    private String nome;
+
+    private List<Itinerario> itinerarios;
+}

--- a/src/main/java/com/mobil/repository/LinhaRepository.java
+++ b/src/main/java/com/mobil/repository/LinhaRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface LinhaRepository extends JpaRepository<Linha, Long> {
 
     List<Linha> findByNome(final String nome);
+
+    boolean existsByCodigo(final String codigo);
 }

--- a/src/main/java/com/mobil/util/converter/LinhasToLinhasOutConverter.java
+++ b/src/main/java/com/mobil/util/converter/LinhasToLinhasOutConverter.java
@@ -1,0 +1,28 @@
+package com.mobil.util.converter;
+
+import com.mobil.model.entity.Linha;
+import com.mobil.model.out.LinhaOut;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Component
+public class LinhasToLinhasOutConverter implements Converter<List<Linha>, List<LinhaOut>> {
+
+    private final ModelMapper modelMapper;
+
+    @Override
+    public List<LinhaOut> convert(final List<Linha> linhas) {
+
+        if (linhas.isEmpty()) {
+            throw new IllegalArgumentException("A lista de LinhaIn não pode ser convertidade em uma lista de Linha.");
+        }
+
+        return linhas.stream().map(linha -> modelMapper.map(linha, LinhaOut.class)).collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,7 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: update
+
+integration:
+  lista-linhas:
+    url: "http://www.poatransporte.com.br/php/facades/process.php?a=nc&p=%&t=o"

--- a/src/test/java/com/mobil/MobilApplicationTests.java
+++ b/src/test/java/com/mobil/MobilApplicationTests.java
@@ -1,13 +1,7 @@
 package com.mobil;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class MobilApplicationTests {
-
-	@Test
-	void contextLoads() {
-	}
-
 }

--- a/src/test/java/com/mobil/integration/service/BuscaLinhasServiceTest.java
+++ b/src/test/java/com/mobil/integration/service/BuscaLinhasServiceTest.java
@@ -1,0 +1,65 @@
+package com.mobil.integration.service;
+
+import com.mobil.integration.model.in.LinhaIn;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mobil.integration.util.enums.MensagemErro.ERRO_INESPERADO;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BuscaLinhasServiceTest {
+
+    @InjectMocks
+    private BuscaLinhasService service;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    private final String url = "url.teste.com";
+
+    @Before
+    public void setup() {
+        ReflectionTestUtils.setField(service, "url", url);
+    }
+
+    @Test
+    public void buscaLinhasSucesso() {
+        final LinhaIn linha1 = new LinhaIn();
+        linha1.setId(1);
+
+        final LinhaIn linha2 = new LinhaIn();
+        linha2.setId(2);
+
+        LinhaIn[] linhasExperadas = new LinhaIn[2];
+        linhasExperadas[0] = linha1;
+        linhasExperadas[1] = linha2;
+
+        when(restTemplate.getForObject(url, LinhaIn[].class)).thenReturn(linhasExperadas);
+
+        final List<LinhaIn> linhasRetornadas = service.buscarLinhas();
+
+        assertEquals(Arrays.asList(linhasExperadas), linhasRetornadas);
+    }
+
+    @Test(expected = ResponseStatusException.class)
+    public void buscaLinhasErro() {
+        when(restTemplate.getForObject(url, LinhaIn[].class)).thenThrow(new ResponseStatusException(
+                HttpStatus.BAD_GATEWAY,
+                ERRO_INESPERADO.mensagem()));
+
+        service.buscarLinhas();
+    }
+}

--- a/src/test/java/com/mobil/integration/service/CopiaBaseDadosServiceTest.java
+++ b/src/test/java/com/mobil/integration/service/CopiaBaseDadosServiceTest.java
@@ -1,0 +1,68 @@
+package com.mobil.integration.service;
+
+import com.mobil.integration.model.in.LinhaIn;
+import com.mobil.model.out.LinhaOut;
+import com.mobil.util.converter.LinhasToLinhasOutConverter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.modelmapper.internal.bytebuddy.utility.RandomString;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CopiaBaseDadosServiceTest {
+
+    @Mock
+    BuscaLinhasService buscaLinhasService;
+
+    @Mock
+    SalvaLinhasInService salvaLinhasInService;
+
+    @Mock
+    LinhasToLinhasOutConverter linhasToLinhasOutConverter;
+
+    @InjectMocks
+    CopiaBaseDadosService service;
+
+    private List<LinhaIn> linhasIn = new ArrayList<>();
+
+    @Before
+    public void setup() {
+        linhasIn.add(this.createRandomLinhaIn());
+        linhasIn.add(this.createRandomLinhaIn());
+        linhasIn.add(this.createRandomLinhaIn());
+
+        when(buscaLinhasService.buscarLinhas()).thenReturn(linhasIn);
+    }
+
+    @Test
+    public void copiarBaseSucesso() {
+        final List<LinhaOut> linhasOut = service.copiarBaseDados();
+
+        verify(buscaLinhasService).buscarLinhas();
+        verify(salvaLinhasInService).salvarLinhas(linhasIn);
+        verify(linhasToLinhasOutConverter).convert(anyList());
+
+        assertNotNull(linhasOut);
+    }
+
+    private LinhaIn createRandomLinhaIn() {
+        final LinhaIn linhaIn = new LinhaIn();
+        linhaIn.setId(new Random().nextInt());
+        linhaIn.setCodigo(RandomString.make());
+        linhaIn.setNome(RandomString.make());
+
+        return linhaIn;
+    }
+}

--- a/src/test/java/com/mobil/integration/service/SalvaLinhasInServiceTest.java
+++ b/src/test/java/com/mobil/integration/service/SalvaLinhasInServiceTest.java
@@ -1,0 +1,76 @@
+package com.mobil.integration.service;
+
+import com.mobil.integration.model.in.LinhaIn;
+import com.mobil.integration.util.converter.LinhasInToLinhasConverter;
+import com.mobil.model.entity.Linha;
+import com.mobil.repository.LinhaRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.internal.bytebuddy.utility.RandomString;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SalvaLinhasInServiceTest {
+
+    @Mock
+    LinhaRepository repository;
+
+    @Mock
+    LinhasInToLinhasConverter linhasInToLinhasConverter;
+
+    @InjectMocks
+    SalvaLinhasInService service;
+
+    private List<LinhaIn> linhasIn = new ArrayList<>();
+
+    private List<Linha> linhas;
+
+    @Before
+    public void setup() {
+        linhasIn.add(this.createRandomLinhaIn());
+        linhasIn.add(this.createRandomLinhaIn());
+        linhasIn.add(this.createRandomLinhaIn());
+
+        linhas = new LinhasInToLinhasConverter(new ModelMapper()).convert(linhasIn);
+
+        when(linhasInToLinhasConverter.convert(anyList()))
+                .thenReturn(linhas);
+    }
+
+    @Test
+    public void salvarLinhasSucesso() {
+        final List<Linha> linhasRetornadas = service.salvarLinhas(linhasIn);
+
+        verify(linhasInToLinhasConverter).convert(linhasIn);
+
+        linhasIn.forEach(linhaIn -> {
+            verify(repository).existsByCodigo(linhaIn.getCodigo());
+        });
+
+        verify(repository).saveAll(linhas);
+
+        assertNotNull(linhasRetornadas);
+    }
+
+    private LinhaIn createRandomLinhaIn() {
+        final LinhaIn linhaIn = new LinhaIn();
+        linhaIn.setId(new Random().nextInt());
+        linhaIn.setCodigo(RandomString.make());
+        linhaIn.setNome(RandomString.make());
+
+        return linhaIn;
+    }
+}

--- a/src/test/java/com/mobil/integration/util/converter/LinhasInToLinhasConverterTest.java
+++ b/src/test/java/com/mobil/integration/util/converter/LinhasInToLinhasConverterTest.java
@@ -1,0 +1,63 @@
+package com.mobil.integration.util.converter;
+
+import com.mobil.integration.model.in.LinhaIn;
+import com.mobil.model.entity.Linha;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.modelmapper.ModelMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LinhasInToLinhasConverterTest {
+
+    @Mock
+    ModelMapper modelMapper;
+
+    @InjectMocks
+    LinhasInToLinhasConverter converter;
+
+    @Test
+    public void converterSucesso() {
+        final LinhaIn linhaIn1 = new LinhaIn();
+        linhaIn1.setId(1l);
+        linhaIn1.setNome("linhaIn1");
+        linhaIn1.setCodigo("codigo1");
+
+        final LinhaIn linhaIn2 = new LinhaIn();
+        linhaIn2.setId(2l);
+        linhaIn2.setNome("linhaIn2");
+        linhaIn2.setCodigo("codigo2");
+
+        final List<LinhaIn> linhasIn = new ArrayList<>();
+        linhasIn.add(linhaIn1);
+        linhasIn.add(linhaIn2);
+
+        linhasIn.forEach(linhaIn -> {
+            final Linha linha = new Linha();
+            linha.setId(linhaIn.getId());
+            linha.setNome(linhaIn.getNome());
+            linha.setCodigo(linhaIn.getCodigo());
+
+            when(modelMapper.map(linhaIn, Linha.class)).thenReturn(linha);
+        });
+
+        final List<Linha> linhasRetornado = converter.convert(linhasIn);
+
+        assertNotNull(linhasRetornado);
+        assertEquals(linhasIn.size(), linhasRetornado.size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void converterErro() {
+        converter.convert(new ArrayList<>());
+    }
+}

--- a/src/test/java/com/mobil/util/converter/LinhasToLinhasOutConverterTest.java
+++ b/src/test/java/com/mobil/util/converter/LinhasToLinhasOutConverterTest.java
@@ -1,0 +1,62 @@
+package com.mobil.util.converter;
+
+import com.mobil.model.entity.Linha;
+import com.mobil.model.out.LinhaOut;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.modelmapper.ModelMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LinhasToLinhasOutConverterTest {
+
+    @Mock
+    ModelMapper modelMapper;
+
+    @InjectMocks
+    LinhasToLinhasOutConverter converter;
+
+    @Test
+    public void converterSucesso() {
+        final Linha linha1 = new Linha();
+        linha1.setId(1l);
+        linha1.setNome("linha1");
+        linha1.setCodigo("codigo1");
+
+        final Linha linha2 = new Linha();
+        linha2.setId(2l);
+        linha2.setNome("linha2");
+        linha2.setCodigo("codigo2");
+
+        final List<Linha> linhas = new ArrayList<>();
+        linhas.add(linha1);
+        linhas.add(linha2);
+
+        linhas.forEach(linha -> {
+            final LinhaOut linhaOut = new LinhaOut();
+            linhaOut.setNome(linha.getNome());
+            linhaOut.setCodigo(linha.getCodigo());
+
+            when(modelMapper.map(linha, LinhaOut.class)).thenReturn(linhaOut);
+        });
+
+        final List<LinhaOut> linhasOutRetornado = converter.convert(linhas);
+
+        assertNotNull(linhasOutRetornado);
+        assertEquals(linhas.size(), linhasOutRetornado.size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void converterErro() {
+        converter.convert(new ArrayList<>());
+    }
+}


### PR DESCRIPTION
Neste PR foi desenvolvidos as services que serão utlizadas para fazer a copia dos dados de linnhas da API Data Poa.
- Adicionado dependência do Junit 4 e Model Mapper;
- Criado a classe BeanSupplier para englobar os beans da aplicação, também foi criado bean para o RestTemplate e ModelMapper;
- Criado algumas classes de input e output;
- Service para buscar as linhas na API Data Poa;
- Service para salvar as linhas retornadas da API Data Poa;
- Service que faz a copia da base de dados;
- Criaco conversor para converter os tipos de objetos mantendo a integridade dos dados;
- Enum para mensagens de erro da API;
- Testes unitários para as services e os conversores;